### PR TITLE
Add support to detect Ubuntu kernels

### DIFF
--- a/debian/apt-dater-host
+++ b/debian/apt-dater-host
@@ -194,14 +194,12 @@ sub do_status() {
     my %holds;
     my $pos = 0;
     my $DPKGARGS;
-    my $_GETROOT = $GETROOT;
 
     if($DPKGTOOL eq "apt-get") {
 	$DPKGARGS = "--quiet --simulate --fix-broken --allow-unauthenticated";
     }
     elsif($DPKGTOOL eq "aptitude") {
 	$DPKGARGS = "--verbose --assume-yes --quiet --simulate -f --allow-untrusted";
-	$_GETROOT = '';
     }
     else {
 	# unkown DPKG frontend - fallback to apt-get
@@ -209,8 +207,8 @@ sub do_status() {
 	$DPKGARGS = "--quiet --simulate --fix-broken --allow-unauthenticated";
     }
 
-    unless(open(HAPT, "$_GETROOT $DPKGTOOL $DPKGARGS dist-upgrade |")) {
-	print "\nADPERR: Failed to execute '$_GETROOT $DPKGTOOL $DPKGARGS dist-upgrade' ($!).\n";
+    unless(open(HAPT, "$DPKGTOOL $DPKGARGS dist-upgrade |")) {
+	print "\nADPERR: Failed to execute '$DPKGTOOL $DPKGARGS dist-upgrade' ($!).\n";
 	exit(1);
     }
     while(<HAPT>) {
@@ -242,7 +240,7 @@ sub do_status() {
     }
     close(HAPT);
     if($?) {
-	print "\nADPERR: Error executing '$GETROOT $DPKGTOOL $DPKGARGS dist-upgrade' ($?).\n";
+	print "\nADPERR: Error executing '$DPKGTOOL $DPKGARGS dist-upgrade' ($?).\n";
 	exit(1);
     }
 


### PR DESCRIPTION
This adds recognition for Ubuntu kernels that provide the full version string in /proc/version_signature. Here is an example on Ubuntu Precise showing that /proc/version_signature is more useful than /proc/version:

$ cat /proc/version
Linux version 3.2.0-31-generic (buildd@allspice) (gcc version 4.6.3 (Ubuntu/Linaro 4.6.3-1ubuntu5) ) #50-Ubuntu SMP Fri Sep 7 16:16:45 UTC 2012

$ cat /proc/version_signature 
Ubuntu 3.2.0-31.50-generic 3.2.28
