### PR TITLE
Fix spacing in $UpgradeCmd

### DIFF
--- a/debian/apt-dater-host
+++ b/debian/apt-dater-host
@@ -328,7 +328,7 @@ sub do_upgrade() {
     }
     close(HAPT);
 
-    $UpgradeCmd .= '--assume-yes ' if($ASSUMEYES);
+    $UpgradeCmd .= ' --assume-yes' if($ASSUMEYES);
 
     system("$GETROOT $UpgradeCmd");
 }


### PR DESCRIPTION
I got this error: `E: Invalid operation dist-upgrade--assume-yes`

This commit changes the spacing to have it exactly when needed.
