### PR TITLE
Don't use `apt-get dist-upgrade`.

### DIFF
--- a/dpkg/apt-dater-host
+++ b/dpkg/apt-dater-host
@@ -34,7 +34,7 @@ use warnings;
 
 my $CFGFILE = '/etc/apt-dater-host.conf';
 my $DPKGTOOL = 'apt-get';
-my $APTUPGRADE = 'dist-upgrade';
+my $APTUPGRADE = 'upgrade';
 my $ASSUMEYES = 0;
 my $GETROOT = 'sudo';
 my $CLEANUP = 0;


### PR DESCRIPTION
`apt-get dist-upgrade` is unsafe for routine maintenance.  As the name suggests, it's intended for upgrading the distribution.  It's mostly inappropriate for use on production systems, though it might be usable with sufficient prior testing on a parallel system first.  In the event of a conflict, dist-upgrade can remove important packages, without reference to the user.

This patch substitutes the use of `apt-get upgrade`, leaving the user to resolve any conflicts.