### PR TITLE
Jessie's aptitude waits for interactive input (y/n prompt) when runni…

### DIFF
--- a/dpkg/apt-dater-host
+++ b/dpkg/apt-dater-host
@@ -320,7 +320,7 @@ sub do_upgrade() {
 
     # drop -y if any packages would be removed
     if($ASSUMEYES) {
-	unless(open(HAPT, "$UpgradeCmd --simulate |")) {
+	unless(open(HAPT, "$UpgradeCmd --simulate --assume-yes |")) {
 	    print "\nADPERR: Failed to execute '$UpgradeCmd --simulate' ($!).\n";
 	    exit(1);
 	}


### PR DESCRIPTION
Jessie's aptitude waits for interactive input (y/n prompt) when running --simulate, this patch adds --assume-yes (work as well with apt-get even if unneeded for it)