### PR TITLE
differentiate security updates

### DIFF
--- a/dpkg/apt-dater-host
+++ b/dpkg/apt-dater-host
@@ -196,6 +196,7 @@ sub do_status() {
 
     # get packages which might be upgraded
     my %updates;
+    my %security_updates;
     my %holds;
     my $pos = 0;
     my $DPKGARGS;
@@ -241,7 +242,18 @@ sub do_status() {
 	    }
 	}
 
-	$updates{$1} = $2 if (/^Inst (\S+) \[.+\] \((\S+) /);
+	# an "Inst" line has a form like this:
+	#
+	#    Inst qgis-common [1:2.18.16+24xenial-ubuntugis] (1:3.0.0+24xenial-ubuntugis QGIS repository:xenial [all]) []
+	#
+	if (/^Inst (\S+) \[.+\] \((\S+) ([^:]+\S+)/) {
+	    my $pkg = $1;
+	    $updates{$pkg} = $2;
+	    # check for security upgrade based on
+	    # https://github.com/monitoring-plugins/monitoring-plugins/blob/master/plugins/check_apt.c#L57
+	    #
+	    $security_updates{$pkg} = ($3 =~ /Debian-Security:|Ubuntu:[^\/]*\/[^-]*-security/) ? 1 : 0;
+	}
     }
     close(HAPT);
     if($?) {
@@ -272,7 +284,7 @@ sub do_status() {
 	    $status{$pkg} = 'h';
 	}
 	elsif($updates{$pkg}) {
-	    $status{$pkg} = 'u';
+	    $status{$pkg} = $security_updates{$pkg} ? 'U' : 'u';
 	}
 	else {
 	    $status{$pkg} = substr($3, 0, 1);


### PR DESCRIPTION
The intent of this patch is to be able to differentiate between 'security' and other updates.

Package updates which are security updates get a status of 'U' instead of status 'u'.

This patch should be understood as a proof of concept that works.

What is missing from this patch is:
* a bump of the protocol version
* updates to the protocol documentation

I'd very much appreciate the inclusion of this /feature/. It does not need to be implemented the way I did it. In particular, maybe using a 'U' for signaling a *security* update could be debated.

I'd ask to please comment on this patch. (Merging it is of course also very fine ;-) 