### PR TITLE
Fix reboot-needed for Bionic kernels

### DIFF
--- a/dpkg/apt-dater-host
+++ b/dpkg/apt-dater-host
@@ -376,7 +376,7 @@ sub do_kernel() {
     }
 
     my $reboot = 0;
-    unless(open(HDPKG, "dpkg-query -W -f='\${Version} \${Status;20} \${Maintainer} \${Provides}\n' 'linux-image*'|grep -E 'install ok installed (Debian|Ubuntu) Kernel Team'|grep linux-image|")) {
+    unless(open(HDPKG, "dpkg-query -W -f='\${Version} \${Status;20} \${Maintainer} \${Provides}\n' 'linux-image*'|grep -E 'install ok installed (Debian|Ubuntu|Canonical) Kernel Team'|grep linux-image|")) {
 	print "$infostr 9 $version\n";
 	return;
     }


### PR DESCRIPTION
For some reason Ubuntu kernel packages have their maintainer set to
Canonical Kernel Team. The -generic and -virtual meta packages are still
built by the Ubuntu Kernel Team though:

$ dpkg-query -W -f='${Package} ${Version} ${Status;10} ${Maintainer}\n' 'linux-image*'|grep -E 'install ok'
linux-image-4.15.0-38-generic 4.15.0-38.41 install ok Canonical Kernel Team <kernel-team@lists.ubuntu.com>
linux-image-4.15.0-39-generic 4.15.0-39.42 install ok Canonical Kernel Team <kernel-team@lists.ubuntu.com>
linux-image-4.15.0-42-generic 4.15.0-42.45 install ok Canonical Kernel Team <kernel-team@lists.ubuntu.com>
linux-image-virtual 4.15.0.42.44 install ok Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>

This makes apt-dater-host return:

KERNELINFO: 1 4.15.0-39-generic

Instead of:

KERNELINFO: 0 4.15.0-39-generic