### PR TITLE
Add config file for apk

### DIFF
--- a/apk/Makefile
+++ b/apk/Makefile
@@ -7,6 +7,14 @@ install:
 	install -D -m0755 apt-dater-host \
 		$(DESTDIR)/usr/bin/apt-dater-host
 
+	install -m0755 -d $(DESTDIR)/etc/
+	install -m0644 apt-dater-host.conf \
+		$(DESTDIR)/etc/apt-dater-host.conf
+
 	install -m0750 -d $(DESTDIR)/etc/sudoers.d
 	install -m0640 apt-dater-host-sudoers \
 		$(DESTDIR)/etc/sudoers.d/apt-dater-host
+
+	install -m0750 -d $(DESTDIR)/etc/doas.d
+	install -m0640 apt-dater-host-doas \
+		$(DESTDIR)/etc/doas.d/apt-dater-host.conf

--- a/apk/apt-dater-host
+++ b/apk/apt-dater-host
@@ -34,6 +34,10 @@ APK_CMD="/sbin/apk"
 VIRT_WHAT_CMD="/usr/sbin/virt-what --test-root=/"
 DMESG_CMD="dmesg"
 
+FORBID_REFRESH=0
+FORBID_UPGRADE=0
+FORBID_INSTALL=0
+
 cfg="/etc/apt-dater-host.conf"
 [ -r $cfg ] && . $cfg
 
@@ -144,7 +148,11 @@ get_kern()
 # FORBID: ${Operations}
 check_forbid()
 {
-	echo "FORBID: 0"
+	mask=0
+	[ $FORBID_REFRESH -eq 1 ] && mask=$((mask|=1))
+	[ $FORBID_UPGRADE -eq 1 ] && mask=$((mask|=2))
+	[ $FORBID_INSTALL -eq 1 ] && mask=$((mask|=4))
+	echo "FORBID: $mask"
 }
 
 #  ADPROTO: ${ProtoVersion}
@@ -183,6 +191,10 @@ run_as_root()
 	fi
 }
 
+echoerr()
+{
+	printf "\n%s\n\n" "$@" 1>&2
+}
 
 if [ -z "$1" ]; then
 	echo "Don't call this script directly!"
@@ -192,7 +204,11 @@ fi
 case "$1" in
 	refresh)
 		say_hi
-		run_as_root 0 $APK_CMD update
+		if [ $FORBID_REFRESH -eq 1 ]; then
+			echoerr "** Sorry, apt-dater based refreshs on this host are disabled! **"
+		else
+			run_as_root 0 $APK_CMD update
+		fi
 		do_status
 		;;
 
@@ -202,13 +218,21 @@ case "$1" in
 		;;
 
 	upgrade)
-		run_as_root 1 $APK_CMD upgrade
+		if [ $FORBID_UPGRADE -eq 1 ]; then
+			echoerr "** Sorry, apt-dater based upgrades on this host are disabled! **"
+		else
+			run_as_root 1 $APK_CMD upgrade
+		fi
 		;;
 
 	install)
 		shift
-		echo "Installing PKG: $*"
-		run_as_root 1 $APK_CMD add $*
+		if [ $FORBID_INSTALL -eq 1 ]; then
+			echoerr "** Sorry, apt-dater based installations on this host are disabled! **"
+		else
+			echo "Installing PKG: $*"
+			run_as_root 1 $APK_CMD add $*
+		fi
 		;;
 
 	kernel)

--- a/apk/apt-dater-host
+++ b/apk/apt-dater-host
@@ -10,7 +10,7 @@
 #   Henrik Riomar <henrik.riomar@gmail.com>
 #
 # Copyright Holder:
-#   2016-2018 (C) Henrik Riomar
+#   2016-2018, 2021 (C) Henrik Riomar
 #
 # License:
 #   This program is free software; you can redistribute it and/or modify
@@ -29,10 +29,13 @@
 #
 
 ADP_VERSION="0.6"
-ROOT_CMD="sudo"
+ROOT_CMD="doas"
 APK_CMD="/sbin/apk"
 VIRT_WHAT_CMD="/usr/sbin/virt-what --test-root=/"
 DMESG_CMD="dmesg"
+
+cfg="/etc/apt-dater-host.conf"
+[ -r $cfg ] && . $cfg
 
 err=255 # exit code returned by Perl from die()
 

--- a/apk/apt-dater-host-doas
+++ b/apk/apt-dater-host-doas
@@ -1,0 +1,7 @@
+# apt-dater-host doas.d config file
+# ------------------------------------
+#
+
+# Keep http_proxy environment variable
+# Allow members of group adm to execute the apk command
+#permit nopass setenv { http_proxy } :adm cmd /sbin/apk

--- a/apk/apt-dater-host.conf
+++ b/apk/apt-dater-host.conf
@@ -5,3 +5,18 @@
 # use this command to become root
 # Supported: doas and sudo
 #ROOT_CMD="doas"
+
+##
+## If this host is a mission critical system and
+## needs scheduled downtimes for upgrades, enable
+## (some) of the following FORBID_* lines:
+##
+
+# prevent apt-dater-host from refreshing package lists
+#FORBID_REFRESH=1
+
+# prevent apt-dater-host from upgrading packages
+#FORBID_UPGRADE=1
+
+# prevent apt-dater-host from installing packages
+#FORBID_INSTALL=1

--- a/apk/apt-dater-host.conf
+++ b/apk/apt-dater-host.conf
@@ -1,0 +1,7 @@
+# front-end for apk to use
+# Supported: apk
+#APK_CMD="/sbin/apk"
+
+# use this command to become root
+# Supported: doas and sudo
+#ROOT_CMD="doas"

--- a/apk/test-apt-dater-host
+++ b/apk/test-apt-dater-host
@@ -60,3 +60,22 @@ test_get_virt()
 	result="$(get_kern)"
 	check_tag KERNELINFO $result
 }
+
+@test "check_forbid()" {
+	# check defaults
+	result="$(check_forbid)"
+	check_tag FORBID $result
+	[[ "$result" == "FORBID: 0" ]]
+
+	export FORBID_UPGRADE=1
+	result="$(check_forbid)"
+	[[ "$result" == "FORBID: 2" ]]
+
+	export FORBID_INSTALL=1
+	result="$(check_forbid)"
+	[[ "$result" == "FORBID: 6" ]]
+
+	export FORBID_REFRESH=1
+	result="$(check_forbid)"
+	[[ "$result" == "FORBID: 7" ]]
+}


### PR DESCRIPTION
Add a config file for `apk`

* Support selecting between `doas `and `sudo` (`doas` is the new default)
* Support setting `FORBID_*` lines
* Add `doas` config file so `apt-dater-host` can use `apk` on a system with `doas`